### PR TITLE
fix patchelf v0.18 errors

### DIFF
--- a/balfrin/packages.yaml
+++ b/balfrin/packages.yaml
@@ -1,4 +1,9 @@
 packages:
+  # patchelf v0.18 leads to errors when it was used to set RPATHS
+  #   ELF load command address/offset not properly aligned
+  # c.f.  https://github.com/NixOS/patchelf/issues/492
+  patchelf:
+    require: "@:0.17"
   libfabric:
     buildable: false
     externals:

--- a/clariden/packages.yaml
+++ b/clariden/packages.yaml
@@ -1,4 +1,9 @@
 packages:
+  # patchelf v0.18 leads to errors when it was used to set RPATHS
+  #   ELF load command address/offset not properly aligned
+  # c.f.  https://github.com/NixOS/patchelf/issues/492
+  patchelf:
+    require: "@:0.17"
   libfabric:
     buildable: false
     externals:

--- a/hohgant/packages.yaml
+++ b/hohgant/packages.yaml
@@ -1,4 +1,9 @@
 packages:
+  # patchelf v0.18 leads to errors when it was used to set RPATHS
+  #   ELF load command address/offset not properly aligned
+  # c.f.  https://github.com/NixOS/patchelf/issues/492
+  patchelf:
+    require: "@:0.17"
   libfabric:
     buildable: false
     externals:

--- a/pilatus/packages.yaml
+++ b/pilatus/packages.yaml
@@ -1,4 +1,9 @@
 packages:
+  # patchelf v0.18 leads to errors when it was used to set RPATHS
+  #   ELF load command address/offset not properly aligned
+  # c.f.  https://github.com/NixOS/patchelf/issues/492
+  patchelf:
+    require: "@:0.17"
   libfabric:
     buildable: false
     externals:


### PR DESCRIPTION
When used to set RPATHS (e.g. installing nvhpc, intel oneapi, cray-mpich):
  ELF load command address/offset not properly aligned
c.f.  https://github.com/NixOS/patchelf/issues/492