### PR TITLE
add tasnam config with minimial required version for cray-pmi

### DIFF
--- a/tasna/compilers.yaml
+++ b/tasna/compilers.yaml
@@ -1,0 +1,14 @@
+compilers:
+- compiler:
+    spec: gcc@7.5.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/tasna/concretizer.yaml
+++ b/tasna/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: false

--- a/tasna/packages.yaml
+++ b/tasna/packages.yaml
@@ -1,0 +1,28 @@
+packages:
+  # patchelf v0.18 leads to errors when it was used to set RPATHS
+  #   ELF load command address/offset not properly aligned
+  # c.f.  https://github.com/NixOS/patchelf/issues/492
+  patchelf:
+    require: "@:0.17"
+  cray-pmi:
+    require: "@6.1.11:"
+  libfabric:
+    buildable: false
+    externals:
+    - spec: libfabric@1.15.2.0
+      prefix: /opt/cray/libfabric/1.15.2.0/
+  slurm:
+    buildable: false
+    externals:
+    - spec: slurm@23-02-1
+      prefix: /usr
+  rdma-core:
+    buildable: false
+    externals:
+    - spec: rdma-core@38.0
+      prefix: /usr
+  xpmem:
+    buildable: false
+    externals:
+    - spec: xpmem@2.6.2
+      prefix: /opt/cray/xpmem/2.6.2-2.5_2.27__gd067c3f.shasta/


### PR DESCRIPTION
- require at least cray-pmi 6.1.11
- update version for slurm/rdma-core/xpmem