### PR TITLE
clariden/santis: update xpmem version

### DIFF
--- a/clariden/packages.yaml
+++ b/clariden/packages.yaml
@@ -22,5 +22,5 @@ packages:
   xpmem:
     buildable: false
     externals:
-    - spec: xpmem@2.4.4
-      prefix: /opt/cray/xpmem/2.4.4-2.3_13.8__gff0e1d9.shasta
+    - spec: xpmem@2.5.1
+      prefix: /opt/cray/xpmem/2.5.2-2.4_3.60__gd0f7936.shasta/

--- a/santis/packages.yaml
+++ b/santis/packages.yaml
@@ -4,6 +4,11 @@ packages:
   # c.f.  https://github.com/NixOS/patchelf/issues/492
   patchelf:
     require: "@:0.17"
+  xpmem:
+    buildable: false
+    externals:
+    - spec: xpmem@2.8.2
+      prefix: /opt/cray/xpmem/2.8.2-1.0_3.5__g84a27a5.shasta/
   libfabric:
     buildable: false
     externals:


### PR DESCRIPTION
current xpmem version on clariden is `2.5.2` (on compute nodes).  The login nodes still have `2.4.4` installed.