### PR TITLE
Add external slurm to santis configuration

### DIFF
--- a/santis/packages.yaml
+++ b/santis/packages.yaml
@@ -14,3 +14,8 @@ packages:
     externals:
     - spec: libfabric@1.15.2.0
       prefix: /opt/cray/libfabric/1.15.2.0/
+  slurm:
+    buildable: false
+    externals:
+    - spec: slurm@23-02-6
+      prefix: /usr


### PR DESCRIPTION
External slurm is required for OpenMPI to work with slurm.

This is obviously suboptimal from the perspective of "minimize number of system packages". Currently this is required to be able to use OpenMPI on multiple nodes with slurm on santis. If I understand correctly, if slurm were updated a newer version with support for PMIx this would maybe not be needed anymore, so this is possibly only temporary. I think cray-mpich would be unaffected by this change. I would also expect OpenMPI to be a "best effort" alternative, without any guarantees of it working, so I don't know how much we care about potential breakage with slurm being updated on the system.

What do you think would be best to do here? Note, in https://confluence.cscs.ch/display/PLATFINTEGR/OpenMPI+on+Santis I've assumed that the external slurm will be added manually by someone building OpenMPI.