### PR TITLE
fix get_rpaths for spack@develop

### DIFF
--- a/site/repo/packages/cray-gtl/package.py
+++ b/site/repo/packages/cray-gtl/package.py
@@ -81,8 +81,9 @@ class CrayGtl(Package):
         # Those rpaths are already set in the build environment, so
         # let's just retrieve them.
         pkgs = os.getenv("SPACK_RPATH_DIRS", "").split(":")
+        pkgs_store = os.getenv("SPACK_STORE_RPATH_DIRS", "").split(":")
         compilers = os.getenv("SPACK_COMPILER_IMPLICIT_RPATHS", "").split(":")
-        return ":".join([p for p in pkgs + compilers if p])
+        return ":".join([p for p in pkgs + compilers + pkgs_store if p])
 
     def should_patch(self, file):
         # Returns true if non-symlink ELF file.

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -115,8 +115,9 @@ class CrayMpich(Package):
         # Those rpaths are already set in the build environment, so
         # let's just retrieve them.
         pkgs = os.getenv("SPACK_RPATH_DIRS", "").split(":")
+        pkgs_store = os.getenv("SPACK_STORE_RPATH_DIRS", "").split(":")
         compilers = os.getenv("SPACK_COMPILER_IMPLICIT_RPATHS", "").split(":")
-        return ":".join([p for p in pkgs + compilers if p])
+        return ":".join([p for p in pkgs + compilers + pkgs_store if p])
 
     def should_patch(self, file):
         # Returns true if non-symlink ELF file.

--- a/site/repo/packages/cray-pals/package.py
+++ b/site/repo/packages/cray-pals/package.py
@@ -61,8 +61,9 @@ class CrayPals(Package):
         # Those rpaths are already set in the build environment, so
         # let's just retrieve them.
         pkgs = os.getenv("SPACK_RPATH_DIRS", "").split(":")
+        pkgs_store = os.getenv("SPACK_STORE_RPATH_DIRS", "").split(":")
         compilers = os.getenv("SPACK_COMPILER_IMPLICIT_RPATHS", "").split(":")
-        return ":".join([p for p in pkgs + compilers if p])
+        return ":".join([p for p in pkgs + compilers + pkgs_store if p])
 
     def should_patch(self, file):
         # Returns true if non-symlink ELF file.

--- a/site/repo/packages/cray-pmi/package.py
+++ b/site/repo/packages/cray-pmi/package.py
@@ -75,8 +75,9 @@ class CrayPmi(Package):
         # Those rpaths are already set in the build environment, so
         # let's just retrieve them.
         pkgs = os.getenv("SPACK_RPATH_DIRS", "").split(":")
+        pkgs_store = os.getenv("SPACK_STORE_RPATH_DIRS", "").split(":")
         compilers = os.getenv("SPACK_COMPILER_IMPLICIT_RPATHS", "").split(":")
-        return ":".join([p for p in pkgs + compilers if p])
+        return ":".join([p for p in pkgs + compilers + pkgs_store if p])
 
     def should_patch(self, file):
         # Returns true if non-symlink ELF file.


### PR DESCRIPTION
It looks like some spack internals have changed. We observed that `libmpi_cuda_gtl.so` had missing rpaths to cuda etc.

Using `spack@v0.21.2`, the build-environment for `cray-gtl` is:

```
build-env >>> spack -e . build-env cray-gtl -- bash
simonpi@nid005450:/dev/shm/simonpi/build-bwrap/environments/test_mpi-env> env | grep RPATH
SPACK_CC_RPATH_ARG=-Wl,-rpath,
SPACK_FC_RPATH_ARG=-Wl,-rpath,
SPACK_COMPILER_IMPLICIT_RPATHS=[...]
SPACK_CXX_RPATH_ARG=-Wl,-rpath,
SPACK_RPATH_DIRS=[cray-gtl, cuda, libxml, zlib-ng, xz, libiconv]
SPACK_F77_RPATH_ARG=-Wl,-rpath,
```

for `spack@develop` the same is:
```
simonpi@nid005802:/dev/shm/simonpi/build-bwrap/environments/test_mpi-env> env | grep RPATH
SPACK_CC_RPATH_ARG=-Wl,-rpath,
SPACK_FC_RPATH_ARG=-Wl,-rpath,
SPACK_COMPILER_IMPLICIT_RPATHS=[...]
SPACK_CXX_RPATH_ARG=-Wl,-rpath,
SPACK_RPATH_DIRS=
SPACK_STORE_RPATH_DIRS=[cray-gtl,cuda,libxml,zlib-ng,xz,gcc-runtime]
SPACK_F77_RPATH_ARG=-Wl,-rpath,
```

The content of `SPACK_RPATH_DIRS` (used in `get_rpaths` in cray-mpich recipes) is now in `SPACK_STORE_RPATH_DIRS` and `SPACK_RPATH_DIRS` is empty.


-> use both `SPACK_RPATH_DIRS` (empty in spack@develop) and the new `SPACK_STORE_RPATH_DIRS` in the `get_rpath` function.