### PR TITLE
[santis] Add EGL as external package

### DIFF
--- a/santis/packages.yaml
+++ b/santis/packages.yaml
@@ -19,3 +19,8 @@ packages:
     externals:
     - spec: slurm@23-02-6
       prefix: /usr
+  egl:
+    buildable: false
+    externals:
+    - spec: egl@1.5
+      prefix: /usr


### PR DESCRIPTION
EGL is a dependency for Paraview and in spack it is currently a placeholder package (i.e. cannot be built, see [here](https://github.com/spack/spack/blob/b79761b7eb5eb2e2d6b8174c3043524462772bf6/var/spack/repos/builtin/packages/egl/package.py#L45-L64)).