### PR TITLE
cray-mpich 8.1.30

### DIFF
--- a/site/repo/packages/cray-gtl/package.py
+++ b/site/repo/packages/cray-gtl/package.py
@@ -10,6 +10,9 @@ import spack.compilers
 from spack.package import *
 
 _versions = {
+    "8.1.30": {
+        "Linux-aarch64": "e240114b97d993d3e30227bd564c3b7eaaaf353a0bde73d64ea0e586737a4f7f",
+    },
     "8.1.29": {
         "Linux-aarch64": "321bc3bc3c17f38d199e0ccae87cc931f69ca58238385f1e6a6165a2fbe94a71",
     },
@@ -122,3 +125,10 @@ class CrayGtl(Package):
                 if "@8.1.27+cuda" in self.spec:
                     patchelf("--add-needed", "libcudart.so", f, fail_on_error=False)
                     patchelf("--add-needed", "libcuda.so", f, fail_on_error=False)
+
+    @run_after("install")
+    def fixup_pkgconfig(self):
+        for root, _, files in os.walk(self.prefix):
+            for name in files:
+                if name[-3:] == '.pc':
+                    filter_file("@@PREFIX@@", self.prefix, name, string=True)

--- a/site/repo/packages/cray-gtl/package.py
+++ b/site/repo/packages/cray-gtl/package.py
@@ -131,4 +131,5 @@ class CrayGtl(Package):
         for root, _, files in os.walk(self.prefix):
             for name in files:
                 if name[-3:] == '.pc':
-                    filter_file("@@PREFIX@@", self.prefix, name, string=True)
+                    f = os.path.join(root, name)
+                    filter_file("@@PREFIX@@", self.prefix, f, string=True)

--- a/site/repo/packages/cray-gtl/package.py
+++ b/site/repo/packages/cray-gtl/package.py
@@ -12,6 +12,7 @@ from spack.package import *
 _versions = {
     "8.1.30": {
         "Linux-aarch64": "aff06f4e5ed1d56d7e879052ba46fdfba06c20ea9c8a1267ca5114cd06207afb",
+        "Linux-x86_64": "5497bbd41c0e1158800c0d4ed894cb7f113a7eb54a4ba0dc2ce47dd23ee6aaa1",
     },
     "8.1.29": {
         "Linux-aarch64": "321bc3bc3c17f38d199e0ccae87cc931f69ca58238385f1e6a6165a2fbe94a71",

--- a/site/repo/packages/cray-gtl/package.py
+++ b/site/repo/packages/cray-gtl/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "8.1.30": {
-        "Linux-aarch64": "e240114b97d993d3e30227bd564c3b7eaaaf353a0bde73d64ea0e586737a4f7f",
+        "Linux-aarch64": "aff06f4e5ed1d56d7e879052ba46fdfba06c20ea9c8a1267ca5114cd06207afb",
     },
     "8.1.29": {
         "Linux-aarch64": "321bc3bc3c17f38d199e0ccae87cc931f69ca58238385f1e6a6165a2fbe94a71",

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "8.1.30": {
-        "Linux-aarch64": "5e1c7c7c6e4dd7f45469b19add3773139f1cf467ea59c5270a88694b7b6ae9c6",
+        "Linux-aarch64": "5b32cdf614e07b2cc06cb5d91d32dcf96443fc1f704520882f5ac6e309b4cfb9",
     },
     "8.1.29": {
         "Linux-aarch64": "2fc5d1f5743f9cecc0b5dbf13355c25014f96db2386b5c2c2d8495a57b279381",

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -12,6 +12,7 @@ from spack.package import *
 _versions = {
     "8.1.30": {
         "Linux-aarch64": "18f0b403c7ce586926c3f6f7a64e412889f59f596145e17edbe8778a245372a6",
+        "Linux-x86_64": "c16b2b113a4af1d10eccc2ba1d1316571baf331ab3904f1fca8d6a767c22720b",
     },
     "8.1.29": {
         "Linux-aarch64": "2fc5d1f5743f9cecc0b5dbf13355c25014f96db2386b5c2c2d8495a57b279381",

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "8.1.30": {
-        "Linux-aarch64": "5b32cdf614e07b2cc06cb5d91d32dcf96443fc1f704520882f5ac6e309b4cfb9",
+        "Linux-aarch64": "18f0b403c7ce586926c3f6f7a64e412889f59f596145e17edbe8778a245372a6",
     },
     "8.1.29": {
         "Linux-aarch64": "2fc5d1f5743f9cecc0b5dbf13355c25014f96db2386b5c2c2d8495a57b279381",

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "8.1.30": {
-        "Linux-aarch64": "e916220e4e37f0c7c57fb4cfb1ce370f99348a6e1fb9ce036c2002e579fd172c",
+        "Linux-aarch64": "5e1c7c7c6e4dd7f45469b19add3773139f1cf467ea59c5270a88694b7b6ae9c6",
     },
     "8.1.29": {
         "Linux-aarch64": "2fc5d1f5743f9cecc0b5dbf13355c25014f96db2386b5c2c2d8495a57b279381",

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -186,7 +186,8 @@ class CrayMpich(Package):
         for root, _, files in os.walk(self.prefix):
             for name in files:
                 if name[-3:] == '.pc':
-                    filter_file("@@PREFIX@@", self.prefix, name, string=True)
+                    f = os.path.join(root, name)
+                    filter_file("@@PREFIX@@", self.prefix, f, string=True)
 
     @property
     def headers(self):

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "8.1.30": {
-        "Linux-aarch64": "88f5dee3714fd97528b6c0922fe9d9801f7c040cefc4e2b2d06a0f2dfdfc2a55",
+        "Linux-aarch64": "e916220e4e37f0c7c57fb4cfb1ce370f99348a6e1fb9ce036c2002e579fd172c",
     },
     "8.1.29": {
         "Linux-aarch64": "2fc5d1f5743f9cecc0b5dbf13355c25014f96db2386b5c2c2d8495a57b279381",

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -10,6 +10,9 @@ import spack.compilers
 from spack.package import *
 
 _versions = {
+    "8.1.30": {
+        "Linux-aarch64": "88f5dee3714fd97528b6c0922fe9d9801f7c040cefc4e2b2d06a0f2dfdfc2a55",
+    },
     "8.1.29": {
         "Linux-aarch64": "2fc5d1f5743f9cecc0b5dbf13355c25014f96db2386b5c2c2d8495a57b279381",
     },
@@ -79,6 +82,7 @@ class CrayMpich(Package):
         "8.1.27",
         "8.1.28",
         "8.1.29",
+        "8.1.30",
     ]:
         with when("+cuda"):
             depends_on(f"cray-gtl@{ver} +cuda", type="link", when="@" + ver)
@@ -176,6 +180,13 @@ class CrayMpich(Package):
         filter_file(
             "@@GTL_LIBRARY@@", gtl_library, self.prefix.bin.mpifort, string=True
         )
+
+    @run_after("install")
+    def fixup_pkgconfig(self):
+        for root, _, files in os.walk(self.prefix):
+            for name in files:
+                if name[-3:] == '.pc':
+                    filter_file("@@PREFIX@@", self.prefix, name, string=True)
 
     @property
     def headers(self):

--- a/site/repo/packages/cray-pals/package.py
+++ b/site/repo/packages/cray-pals/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "1.3.2": {
-        "Linux-aarch64": "f7b97a10cc8dde17e804f79235ab1aa98f83e0c7c178e58d6ca3e9170f89c6da",
+        "Linux-aarch64": "53c8ecd0bc6466afb6265ff5d91c14086b4259b7ce768fc120b32f53f39385db",
         "Linux-x86_64": "deea749476de0f545b31fcd0912f133d7ba60b84f673e47d8b4b15d5a117254c",
     },
     "1.2.12": {
@@ -88,3 +88,10 @@ class CrayPals(Package):
                 if not self.should_patch(f):
                     continue
                 patchelf("--force-rpath", "--set-rpath", rpath, f, fail_on_error=False)
+
+    @run_after("install")
+    def fixup_pkgconfig(self):
+        for root, _, files in os.walk(self.prefix):
+            for name in files:
+                if name[-3:] == '.pc':
+                    filter_file("@@PREFIX@@", self.prefix, name, string=True)

--- a/site/repo/packages/cray-pals/package.py
+++ b/site/repo/packages/cray-pals/package.py
@@ -12,7 +12,7 @@ from spack.package import *
 _versions = {
     "1.3.2": {
         "Linux-aarch64": "cdc50b007a6968ed151e95e08afe0d3121db11218dc9fd9fcaf94ccfa889e327",
-        "Linux-x86_64": "deea749476de0f545b31fcd0912f133d7ba60b84f673e47d8b4b15d5a117254c",
+        "Linux-x86_64": "5eb6c1d4b92a61dc2f0a7fc67fe2733316969902eb005651fc2b215d1d870752",
     },
     "1.2.12": {
         "Linux-x86_64": "c94d29c09ed650c4e98a236df7ced77f027bdf987919a91a1a1382f704a85bb9"

--- a/site/repo/packages/cray-pals/package.py
+++ b/site/repo/packages/cray-pals/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "1.3.2": {
-        "Linux-aarch64": "53c8ecd0bc6466afb6265ff5d91c14086b4259b7ce768fc120b32f53f39385db",
+        "Linux-aarch64": "cdc50b007a6968ed151e95e08afe0d3121db11218dc9fd9fcaf94ccfa889e327",
         "Linux-x86_64": "deea749476de0f545b31fcd0912f133d7ba60b84f673e47d8b4b15d5a117254c",
     },
     "1.2.12": {

--- a/site/repo/packages/cray-pals/package.py
+++ b/site/repo/packages/cray-pals/package.py
@@ -94,4 +94,5 @@ class CrayPals(Package):
         for root, _, files in os.walk(self.prefix):
             for name in files:
                 if name[-3:] == '.pc':
-                    filter_file("@@PREFIX@@", self.prefix, name, string=True)
+                    f = os.path.join(root, name)
+                    filter_file("@@PREFIX@@", self.prefix, f, string=True)

--- a/site/repo/packages/cray-pmi/package.py
+++ b/site/repo/packages/cray-pmi/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "6.1.15": {
-        "Linux-aarch64": "84acb000e42854de97edf4533cf485b73575163582378c7684c15fe3b4cfe11d",
+        "Linux-aarch64": "e8280ca3db700c26c70d13cb13dde63929644d7636ba8fbc4aaa3e088037d2f5",
     },
     "6.1.14": {
         "Linux-aarch64": "763933310db675c3e690c9a121778c2ddc3a0b8672cb718542888e31099e25c7",

--- a/site/repo/packages/cray-pmi/package.py
+++ b/site/repo/packages/cray-pmi/package.py
@@ -12,6 +12,7 @@ from spack.package import *
 _versions = {
     "6.1.15": {
         "Linux-aarch64": "e8280ca3db700c26c70d13cb13dde63929644d7636ba8fbc4aaa3e088037d2f5",
+        "Linux-x86_64": "6f696f5d8f364f659c03c9c836de41749727791a89b6100c4fb6a7dd304b87db",
     },
     "6.1.14": {
         "Linux-aarch64": "763933310db675c3e690c9a121778c2ddc3a0b8672cb718542888e31099e25c7",

--- a/site/repo/packages/cray-pmi/package.py
+++ b/site/repo/packages/cray-pmi/package.py
@@ -115,4 +115,5 @@ class CrayPmi(Package):
         for root, _, files in os.walk(self.prefix):
             for name in files:
                 if name[-3:] == '.pc':
-                    filter_file("@@PREFIX@@", self.prefix, name, string=True)
+                    f = os.path.join(root, name)
+                    filter_file("@@PREFIX@@", self.prefix, f, string=True)

--- a/site/repo/packages/cray-pmi/package.py
+++ b/site/repo/packages/cray-pmi/package.py
@@ -10,6 +10,9 @@ import spack.compilers
 from spack.package import *
 
 _versions = {
+    "6.1.15": {
+        "Linux-aarch64": "84acb000e42854de97edf4533cf485b73575163582378c7684c15fe3b4cfe11d",
+    },
     "6.1.14": {
         "Linux-aarch64": "763933310db675c3e690c9a121778c2ddc3a0b8672cb718542888e31099e25c7",
     },
@@ -106,3 +109,10 @@ class CrayPmi(Package):
                 if not self.should_patch(f):
                     continue
                 patchelf("--force-rpath", "--set-rpath", rpath, f, fail_on_error=False)
+
+    @run_after("install")
+    def fixup_pkgconfig(self):
+        for root, _, files in os.walk(self.prefix):
+            for name in files:
+                if name[-3:] == '.pc':
+                    filter_file("@@PREFIX@@", self.prefix, name, string=True)


### PR DESCRIPTION
cray-mpich 8.1.30 has been released

- new tarballs `cray-mpich 8.1.30`, `cray-pmi@6.1.15`, `cray-gtl@8.1.30`
- update tarball for `cray-pals@1.3.2` 
- add man pages
- add pkgconfig
- cray-mpich provides ofi and ucx (skipped) manpages, only copy ofi directory to the tarball

`cray-mpich@8.1.30` ships with `cray-pals@1.3.2`, which already exists. Thus adding the pkgconfig file changes the hash of it. Shall we just overwrite it? 

TODO:
- [x] check man is working (spack load --sh)
- [x] check pkgconfig is working (spack load --sh)

Since pmi/pals/mpich are not root specs, the pkgconfig/manpath are not present in `uenv view`.

A preview `prgenv-gnu/24.7` is on scratch: `/capstor/scratch/cscs/simonpi/prgenv-gnu-24.7.sqfs`


**Note**: We did not pin the cray-pmi version. Future builds of `cray-mpich@8.1.29` will select `cray-pmi@6.1.15` (the pmi of 8.1.30).