### PR TITLE
packages.yaml, buildable=true for cray-mpich

### DIFF
--- a/balfrin/packages.yaml
+++ b/balfrin/packages.yaml
@@ -2,6 +2,8 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-mpich:
+    buildable: true
   patchelf:
     require: "@:0.17"
   libfabric:

--- a/clariden/packages.yaml
+++ b/clariden/packages.yaml
@@ -2,6 +2,8 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-mpich:
+    buildable: true
   patchelf:
     require: "@:0.17"
   libfabric:

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -2,6 +2,8 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-mpich:
+    buildable: true
   patchelf:
     require: "@:0.17"
   xpmem:

--- a/eiger/packages.yaml
+++ b/eiger/packages.yaml
@@ -2,6 +2,8 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-mpich:
+    buildable: true
   patchelf:
     require: "@:0.17"
   libfabric:

--- a/pilatus/packages.yaml
+++ b/pilatus/packages.yaml
@@ -2,6 +2,8 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-mpich:
+    buildable: true
   patchelf:
     require: "@:0.17"
   libfabric:

--- a/santis/packages.yaml
+++ b/santis/packages.yaml
@@ -2,6 +2,8 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-mpich:
+    buildable: true
   patchelf:
     require: "@:0.17"
   xpmem:

--- a/tasna/packages.yaml
+++ b/tasna/packages.yaml
@@ -2,6 +2,8 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-mpich:
+    buildable: true
   patchelf:
     require: "@:0.17"
   cray-pmi:

--- a/todi/packages.yaml
+++ b/todi/packages.yaml
@@ -2,6 +2,8 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-mpich:
+    buildable: true
   patchelf:
     require: "@:0.17"
   xpmem:


### PR DESCRIPTION
Override a recent change in spack which expects cray-mpich to be non-buildable: https://github.com/spack/spack/blob/develop/etc/spack/defaults/packages.yaml#L76


