### PR TITLE
Update xpmem prefix for pilatus and todi

### DIFF
--- a/pilatus/packages.yaml
+++ b/pilatus/packages.yaml
@@ -25,4 +25,4 @@ packages:
     buildable: false
     externals:
     - spec: xpmem@2.4.4
-      prefix: /opt/cray/xpmem/default
+      prefix: /usr

--- a/todi/packages.yaml
+++ b/todi/packages.yaml
@@ -10,7 +10,7 @@ packages:
     buildable: false
     externals:
     - spec: xpmem@2.8.2
-      prefix: /opt/cray/xpmem/default
+      prefix: /usr
   libfabric:
     buildable: false
     externals:


### PR DESCRIPTION
pilatus and todi are using the new prefix. eiger is unchanged. I can't check the other systems (they don't exist, are down, or I don't have access).