### PR TITLE
Remove nonexistent repos from daint, santis, and todi configurations

### DIFF
--- a/daint/repos.yaml
+++ b/daint/repos.yaml
@@ -1,3 +1,2 @@
 repos:
-- ./repo
 - ../site/repo

--- a/santis/repos.yaml
+++ b/santis/repos.yaml
@@ -1,3 +1,2 @@
 repos:
-- ./repo
 - ../site/repo

--- a/todi/repos.yaml
+++ b/todi/repos.yaml
@@ -1,3 +1,2 @@
 repos:
-- ./repo
 - ../site/repo


### PR DESCRIPTION
The repos themselves were removed in #14, but I missed updating the repos.yaml files.