### PR TITLE
Add preferred version for `aws-ofi-nccl` on clariden, daint, todi

### DIFF
--- a/clariden/packages.yaml
+++ b/clariden/packages.yaml
@@ -1,4 +1,7 @@
 packages:
+  aws-ofi-nccl:
+    version:
+    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -1,4 +1,7 @@
 packages:
+  aws-ofi-nccl:
+    version:
+    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492

--- a/todi/packages.yaml
+++ b/todi/packages.yaml
@@ -1,4 +1,7 @@
 packages:
+  aws-ofi-nccl:
+    version:
+    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492


### PR DESCRIPTION
Prefer the (informally) recommended version of `aws-ofi-nccl` (@teojgo can you confirm?) on clariden, daint, todi. I don't know if other clusters should be updated as well? If yes, please let me know and I'll apply the same change there.

Uses a git version since 1.9.2 didn't make it into spack v0.23.0. Using the git version avoids pulling in (and maintaining) a custom definition of the `aws-ofi-nccl` package. The new versions will be in 0.24 (or 1.0, whatever comes next): https://github.com/spack/spack/pull/47717.

Follow-up to https://github.com/eth-cscs/alps-uenv/pull/159#discussion_r1852406626.