### PR TITLE
Ensure cray-* packages buildable

### DIFF
--- a/balfrin/packages.yaml
+++ b/balfrin/packages.yaml
@@ -2,7 +2,13 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
   cray-mpich:
+    buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
     buildable: true
   patchelf:
     require: "@:0.17"

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -5,7 +5,13 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
   cray-mpich:
+    buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
     buildable: true
   patchelf:
     require: "@:0.17"

--- a/eiger/packages.yaml
+++ b/eiger/packages.yaml
@@ -2,7 +2,13 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
   cray-mpich:
+    buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
     buildable: true
   patchelf:
     require: "@:0.17"

--- a/pilatus/packages.yaml
+++ b/pilatus/packages.yaml
@@ -2,7 +2,13 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
   cray-mpich:
+    buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
     buildable: true
   patchelf:
     require: "@:0.17"

--- a/santis/packages.yaml
+++ b/santis/packages.yaml
@@ -2,7 +2,13 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
   cray-mpich:
+    buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
     buildable: true
   patchelf:
     require: "@:0.17"

--- a/tasna/packages.yaml
+++ b/tasna/packages.yaml
@@ -2,12 +2,17 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
   cray-mpich:
     buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
+    buildable: true
+    require: "@6.1.11:"
   patchelf:
     require: "@:0.17"
-  cray-pmi:
-    require: "@6.1.11:"
   libfabric:
     buildable: false
     externals:

--- a/todi/packages.yaml
+++ b/todi/packages.yaml
@@ -5,7 +5,13 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
   cray-mpich:
+    buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
     buildable: true
   patchelf:
     require: "@:0.17"


### PR DESCRIPTION
With https://github.com/spack/spack/pull/48730 some cray packages have been defined as `buildable: false` and this started triggering error like

```
==> Starting concretization pool with 5 processes
==> Error: failed to concretize `cray-mpich+cuda` for the following reasons:
     1. Attempted to use external for 'cray-pmi' which does not satisfy any configured external spec version
     2. Attempted to use external for 'cray-pmi' which does not satisfy any configured external spec
```

Since currently there is no site-wise `packages.yaml`, this PR went for the easiest path, duplicating this configuration for each cluster.