### PR TITLE
Mi300: cray fix + egl

### DIFF
--- a/adula/packages.yaml
+++ b/adula/packages.yaml
@@ -35,3 +35,8 @@ packages:
     externals:
     - spec: xpmem@2.9.6
       prefix: /usr
+  egl:
+    buildable: false
+    externals:
+      - spec: egl@1.5.0
+        prefix: /usr

--- a/adula/packages.yaml
+++ b/adula/packages.yaml
@@ -5,7 +5,13 @@ packages:
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
   cray-mpich:
+    buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
     buildable: true
   patchelf:
     require: "@:0.17"


### PR DESCRIPTION
Changelog:
- Introduce same fix for `cray-*` packages applied on master needed for newer spack versions
- Add `egl` as external

### `cray-*:buildable:true`

Fix for newer spack versions, where cray packages have been marked as not-buildable. See https://github.com/eth-cscs/alps-cluster-config/pull/20

### EGL

**Why is useful?** First use-case we have is for `hip`, that requires a `gl` provider. Using an external `egl` allows to skip build of `glx` that comes with a quite big tree of dependencies to build (and it seems to bring in also a problem with the concretizer that might end up choosing a not "ideal" configuration).

**About version**. I'm not sure `1.5.0` is correct, but I'm not even sure it would make any difference. I tried to figure it out, but both with `zypper` and with a manually built `eglinfo`, I was not able to pinpoint a single version.

In `eglinfo` I was able to see that both 1.4.0 and 1.5.0 are supported, but it depends on the platform used (probably 1.4.0 might be the correct choice). The name of the library seems to point to 1.1.0, but it sounds a bit off to me.