### PR TITLE
add config for beverin

### DIFF
--- a/beverin/compilers.yaml
+++ b/beverin/compilers.yaml
@@ -1,0 +1,14 @@
+compilers:
+- compiler:
+    spec: gcc@7.5.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: aarch64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/beverin/compilers.yaml
+++ b/beverin/compilers.yaml
@@ -8,7 +8,7 @@ compilers:
       fc: /usr/bin/gfortran
     flags: {}
     operating_system: sles15
-    target: aarch64
+    target: x86_64
     modules: []
     environment: {}
     extra_rpaths: []

--- a/beverin/concretizer.yaml
+++ b/beverin/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: false

--- a/beverin/packages.yaml
+++ b/beverin/packages.yaml
@@ -1,0 +1,34 @@
+packages:
+  # patchelf v0.18 leads to errors when it was used to set RPATHS
+  #   ELF load command address/offset not properly aligned
+  # c.f.  https://github.com/NixOS/patchelf/issues/492
+  cray-gtl:
+    buildable: true
+  cray-mpich:
+    buildable: true
+  cray-pals:
+    buildable: true
+  cray-pmi:
+    buildable: true
+  patchelf:
+    require: "@:0.17"
+  libfabric:
+    buildable: false
+    externals:
+    - spec: libfabric@1.15.2.0
+      prefix: /opt/cray/libfabric/1.15.2.0/
+  slurm:
+    buildable: false
+    externals:
+    - spec: slurm@24-05-4
+      prefix: /usr
+  egl:
+    buildable: false
+    externals:
+    - spec: egl@1.21
+      prefix: /usr
+  xpmem:
+    buildable: false
+    externals:
+    - spec: xpmem@2.9.6
+      prefix: /usr

--- a/beverin/repos.yaml
+++ b/beverin/repos.yaml
@@ -1,0 +1,2 @@
+repos:
+- ../site/repo


### PR DESCRIPTION


Not clear to me what egl should be (the same libwayland-egl is installed on daint, but there the spec is egl@1.5):

```
[beverin][simonpi@nid002550 ~]$ rpm -qi libwayland-egl1-99~1.21.0-150500.1.1.x86_64
warning: Found NDB Packages.db database while attempting bdb backend: using ndb backend.
Name        : libwayland-egl1
Version     : 99~1.21.0
Release     : 150500.1.1
Architecture: x86_64
Install Date: Thu 23 Jan 2025 01:19:52 PM CET
Group       : System/Libraries
Size        : 5984
License     : MIT
Signature   : RSA/SHA256, Fri 02 Dec 2022 10:38:29 AM CET, Key ID 70af9e8139db7c82
Source RPM  : wayland-1.21.0-150500.1.1.src.rpm
Build Date  : Fri 02 Dec 2022 10:37:56 AM CET
Build Host  : sheep05
Relocations : (not relocatable)
Packager    : https://www.suse.com/
Vendor      : SUSE LLC <https://www.suse.com/>
URL         : https://wayland.freedesktop.org/
Summary     : Additional egl functions for wayland
```

@albestro do we need egl on the mi300a/mi200 cluster?