### PR TITLE
Support latest spack with compilers as nodes

### DIFF
--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -79,6 +79,11 @@ class CrayMpich(Package):
 
     provides("mpi")
 
+    # Need access to compilers to fix compiler paths.
+    depends_on("c")
+    depends_on("cxx")
+    depends_on("fortran")
+
     # Fix up binaries with patchelf.
     depends_on("patchelf", type="build")
 
@@ -117,9 +122,12 @@ class CrayMpich(Package):
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)
-        env.set("MPICH_CC", dependent_spec.package.module.spack_cc)
-        env.set("MPICH_CXX", dependent_spec.package.module.spack_cxx)
-        env.set("MPICH_FC", dependent_spec.package.module.spack_fc)
+        if "c" in dependent_spec:
+            env.set("MPICH_CC", dependent_spec["c"].package.cc)
+        if"cxx" in dependent_spec:
+            env.set("MPICH_CXX", dependent_spec["cxx"].package.cxx)
+        if "fortran" in dependent_spec:
+            env.set("MPICH_FC", dependent_spec["fortran"].package.fortran)
 
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.mpicc = join_path(self.prefix.bin, "mpicc")

--- a/site/repo/packages/cuda/package.py
+++ b/site/repo/packages/cuda/package.py
@@ -665,7 +665,8 @@ class Cuda(Package):
             env.append_path("LD_LIBRARY_PATH", libxml2_home.lib)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set("CUDAHOSTCXX", dependent_spec.package.compiler.cxx)
+        if "cxx" in dependent_spec:
+            env.set("CUDAHOSTCXX", dependent_spec["cxx"].package.cxx)
         env.set("CUDA_HOME", self.prefix)
         env.set("NVHPC_CUDA_HOME", self.prefix)
 


### PR DESCRIPTION
Incomplete. These are currently minimal changes to allow using cray-mpich and cuda with spack develop.

For non-cray packages we probably simply want to pull in the latest definitions of the packages from upstream spack (modulo the local changes that have been made to CUDA-related packages regarding multi-CUDA installs etc.).

Not fully tested, but opening this for reference. Feel free to push required changes to other packages as you discover them.