### PR TITLE
cray-mpich: add compiler requirements

### DIFF
--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -75,6 +75,13 @@ class CrayMpich(Package):
     variant("cuda", default=False)
     variant("rocm", default=False)
 
+    requires(
+        "%gcc",
+        "%nvhpc",
+        policy="one_of",
+        msg="GCC and NVHPC are the only supported compilers by the CSCS packaged version.",
+    )
+
     conflicts("+cuda", when="+rocm", msg="Pick either CUDA or ROCM")
 
     provides("mpi")


### PR DESCRIPTION
It happened to me a couple of times that I had to investigate a strange error message like this where it complains about a missing file, specifically an mpi compiler wrapper.

```
[+] /opt/spack/opt/spack/linux-ubuntu22.04-x86_64/clang-15.0.7/curl-8.11.1-est3yhtnaikwwnm63nyvblcbl4wzspn5
==> Installing cray-mpich-8.1.32-kj25fmnxsudtmiqyfpboh2evpib5ojxs [28/39]
==> No binary for cray-mpich-8.1.32-kj25fmnxsudtmiqyfpboh2evpib5ojxs found: installing from source
==> Fetching https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.32.x86_64.tar.gz
==> No patches needed for cray-mpich
==> cray-mpich: Executing phase: 'install'
==> Error: FileNotFoundError: [Errno 2] No such file or directory: '/opt/spack/opt/spack/linux-ubuntu22.04-x86_64/clang-15.0.7/cray-mpich-8.1.32-kj25fmnxsudtmiqyfpboh2evpib5ojxs/bin/mpicc.arwnofsm'
/root/site/repo/packages/cray-mpich/package.py:176, in fixup_compiler_paths:
        174    @run_after("install")
        175    def fixup_compiler_paths(self):
  >>    176        filter_file("@@@@CC@@@@", self.compiler.cc, self.prefix.bin.mpicc, string=True)
        177        filter_file("@@CXX@@", self.compiler.cxx, self.prefix.bin.mpicxx, string=True)
        178        filter_file("@@FC@@", self.compiler.fc, self.prefix.bin.mpifort, string=True)
        179
See build log for details:
  /tmp/root/spack-stage/spack-stage-cray-mpich-8.1.32-kj25fmnxsudtmiqyfpboh2evpib5ojxs/spack-build-out.txt
```

The fact is that it is actually missing, because the custom CSCS package for `cray-mpich` has not been packaged to support all compilers but just, afaik, `gcc` and `nvhcp`.

So the problem above is that it should stop way before trying to install and realise that the compiler wrapper is missing, because `clang` is not in the list of currently supported compilers.

This PR introduces compiler requirements for the `cray-mpich` package, which should prevent this kind of errors by moving this problem to the an earlier phases, namely in concretisation step (hoping that the concretiser is helpful with the error message).

IIRC also @simonpintarelli wanted to introduce something along these lines.