### PR TITLE
Remove version requirement for aws-ofi-nccl

### DIFF
--- a/clariden/packages.yaml
+++ b/clariden/packages.yaml
@@ -1,7 +1,4 @@
 packages:
-  aws-ofi-nccl:
-    version:
-    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -1,7 +1,4 @@
 packages:
-  aws-ofi-nccl:
-    version:
-    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492

--- a/todi/packages.yaml
+++ b/todi/packages.yaml
@@ -1,7 +1,4 @@
 packages:
-  aws-ofi-nccl:
-    version:
-    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492


### PR DESCRIPTION
In preparation for spack 1.0 I'm removing the aws-ofi-nccl version requirement. Spack develop has 1.14.2 nowadays, the latest release.

This is one of many PRs targeting spack 1.0 support.