### PR TITLE
prgenv-gnu/25.06/spack 1.0 omnibus PR

### DIFF
--- a/clariden/packages.yaml
+++ b/clariden/packages.yaml
@@ -18,8 +18,8 @@ packages:
   libfabric:
     buildable: false
     externals:
-    - spec: libfabric@1.15.2.0
-      prefix: /opt/cray/libfabric/1.15.2.0/
+    - spec: libfabric@1.22.0
+      prefix: /opt/cray/libfabric/1.22.0/
   slurm:
     buildable: false
     externals:

--- a/clariden/packages.yaml
+++ b/clariden/packages.yaml
@@ -1,7 +1,4 @@
 packages:
-  aws-ofi-nccl:
-    version:
-    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -23,8 +23,8 @@ packages:
   libfabric:
     buildable: false
     externals:
-    - spec: libfabric@1.15.2.0
-      prefix: /opt/cray/libfabric/1.15.2.0/
+    - spec: libfabric@1.22.0
+      prefix: /opt/cray/libfabric/1.22.0/
   slurm:
     buildable: false
     externals:

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -25,7 +25,7 @@ packages:
   slurm:
     buildable: false
     externals:
-    - spec: slurm@23-11-7
+    - spec: slurm@24-05-3
       prefix: /usr
   egl:
     buildable: false

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -1,7 +1,4 @@
 packages:
-  aws-ofi-nccl:
-    version:
-    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492

--- a/santis/packages.yaml
+++ b/santis/packages.yaml
@@ -15,8 +15,8 @@ packages:
   libfabric:
     buildable: false
     externals:
-    - spec: libfabric@1.15.2.0
-      prefix: /opt/cray/libfabric/1.15.2.0/
+    - spec: libfabric@1.22.0
+      prefix: /opt/cray/libfabric/1.22.0/
   slurm:
     buildable: false
     externals:

--- a/site/repo/packages/cray-mpich/package.py
+++ b/site/repo/packages/cray-mpich/package.py
@@ -86,6 +86,11 @@ class CrayMpich(Package):
 
     provides("mpi")
 
+    # Need access to compilers to fix compiler paths.
+    depends_on("c")
+    depends_on("cxx")
+    depends_on("fortran")
+
     # Fix up binaries with patchelf.
     depends_on("patchelf", type="build")
 
@@ -124,9 +129,12 @@ class CrayMpich(Package):
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)
-        env.set("MPICH_CC", dependent_spec.package.module.spack_cc)
-        env.set("MPICH_CXX", dependent_spec.package.module.spack_cxx)
-        env.set("MPICH_FC", dependent_spec.package.module.spack_fc)
+        if "c" in dependent_spec:
+            env.set("MPICH_CC", dependent_spec["c"].package.cc)
+        if"cxx" in dependent_spec:
+            env.set("MPICH_CXX", dependent_spec["cxx"].package.cxx)
+        if "fortran" in dependent_spec:
+            env.set("MPICH_FC", dependent_spec["fortran"].package.fortran)
 
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.mpicc = join_path(self.prefix.bin, "mpicc")

--- a/site/repo/packages/cuda/package.py
+++ b/site/repo/packages/cuda/package.py
@@ -1,5 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -8,7 +7,7 @@ import platform
 import re
 from glob import glob
 
-import llnl.util.tty as tty
+from spack_repo.builtin.build_systems.generic import Package
 
 from spack.package import *
 
@@ -23,8 +22,27 @@ from spack.package import *
 #  - package key must be in the form '{os}-{arch}' where 'os' is in the
 #    format returned by platform.system() and 'arch' by platform.machine()
 
-preferred_ver = "12.6.0"
 _versions = {
+    "12.9.0": {
+        "Linux-aarch64": (
+            "f3b7ae71f95d11de0a03ccfa1c0aff7be336d2199b50b1a15b03695fd15a6409",
+            "https://developer.download.nvidia.com/compute/cuda/12.9.0/local_installers/cuda_12.9.0_575.51.03_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "bbce2b760fe2096ca1c86f729e03bf377c1519add7b2755ecc4e9b0a9e07ee43",
+            "https://developer.download.nvidia.com/compute/cuda/12.9.0/local_installers/cuda_12.9.0_575.51.03_linux.run",
+        ),
+    },
+    "12.8.1": {
+        "Linux-aarch64": (
+            "353cbab1b57282a1001071796efd95c1e40ec27a3375e854d12637eaa1c6107c",
+            "https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "228f6bcaf5b7618d032939f431914fc92d0e5ed39ebe37098a24502f26a19797",
+            "https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run",
+        ),
+    },
     "12.8.0": {
         "Linux-aarch64": (
             "5bc211f00c4f544da6e3fc3a549b3eb0a7e038439f5f3de71caa688f2f6b132c",
@@ -33,6 +51,16 @@ _versions = {
         "Linux-x86_64": (
             "610867dcd6d94c4e36c4924f1d01b9db28ec08164e8af6c764f21b84200695f8",
             "https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run",
+        ),
+    },
+    "12.6.3": {
+        "Linux-aarch64": (
+            "213ea63a6357020978a8b0a79a8c9d12a2a5941afa1cdc69d5a3f933fa8bed04",
+            "https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/cuda_12.6.3_560.35.05_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "81d60e48044796d7883aa8a049afe6501b843f2c45639b3703b2378de30d55d3",
+            "https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/cuda_12.6.3_560.35.05_linux.run",
         ),
     },
     "12.6.2": {
@@ -85,6 +113,20 @@ _versions = {
             "https://developer.download.nvidia.com/compute/cuda/12.5.0/local_installers/cuda_12.5.0_555.42.02_linux.run",
         ),
     },
+    "12.4.1": {
+        "Linux-aarch64": (
+            "b0fbc77effa225498974625b6b08b3f6eff4a37e379f5b60f1d3827b215ad19b",
+            "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "367d2299b3a4588ab487a6d27276ca5d9ead6e394904f18bccb9e12433b9c4fb",
+            "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "677f44da10dd81396cb53a32c4e26eccdc24912063cb2e3beb3bbcb1658ef451",
+            "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux_ppc64le.run",
+        ),
+    },
     "12.4.0": {
         "Linux-aarch64": (
             "b12bfe6c36d32ecf009a6efb0024325c5fc389fca1143f5f377ae2555936e803",
@@ -93,6 +135,38 @@ _versions = {
         "Linux-x86_64": (
             "e6a842f4eca9490575cdb68b6b1bb78d47b95a897de48dee292c431892e57d17",
             "https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_550.54.14_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "ef9a712daccf2805b4422f2301ff0eaa5c3ad41ef5d64b8626773bce7d1f41fe",
+            "https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_550.54.14_linux_ppc64le.run",
+        ),
+    },
+    "12.3.2": {
+        "Linux-aarch64": (
+            "761b84e292b94c4d330f445d36326dfff90a418e909fb0baf3d6f03e24106d08",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.2/local_installers/cuda_12.3.2_545.23.08_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "24b2afc9f770d8cf43d6fa7adc2ebfd47c4084db01bdda1ce3ce0a4d493ba65b",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.2/local_installers/cuda_12.3.2_545.23.08_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "b876936fc80de10653523eadd846065db346b38ba6296f2d365772259cb2f198",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.2/local_installers/cuda_12.3.2_545.23.08_linux_ppc64le.run",
+        ),
+    },
+    "12.3.1": {
+        "Linux-aarch64": (
+            "bce6bb8b293c33c3ed0c1b65120c70587cc29e1b94ea8679ebb14c32b3858b5e",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.1/local_installers/cuda_12.3.1_545.23.08_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "b73d18ccd5ff85bbae32b425dfb82729612ede65b07a37cd5e2b574190614038",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.1/local_installers/cuda_12.3.1_545.23.08_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "9da7e6e2beadc933aab73de79a84e133ddf03226371d3d7af83502748a978568",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.1/local_installers/cuda_12.3.1_545.23.08_linux_ppc64le.run",
         ),
     },
     "12.3.0": {
@@ -107,6 +181,20 @@ _versions = {
         "Linux-ppc64le": (
             "de15c04380ec35b194c07503bf434837bac5b427cf77b19a63962b1653d195d5",
             "https://developer.download.nvidia.com/compute/cuda/12.3.0/local_installers/cuda_12.3.0_545.23.06_linux_ppc64le.run",
+        ),
+    },
+    "12.2.2": {
+        "Linux-aarch64": (
+            "4113a15e6b27a02638c72edeb5f89de4c9ea312febba12fc4cefff2edc882268",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "2b39aae3e7618d9f59a3c8fa1f1bc61f29c0b0e0df75fb05076badb352952ef2",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "18848278e7f2bd4b4481f5665633d7e3d46e9a562d175d5ff278218188b01342",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux_ppc64le.run",
         ),
     },
     "12.2.1": {
@@ -603,19 +691,15 @@ class Cuda(Package):
 
     homepage = "https://developer.nvidia.com/cuda-zone"
 
-    maintainers("ax3l", "Rombur")
+    maintainers("ax3l", "Rombur", "pauleonix")
     executables = ["^nvcc$"]
 
-    skip_version_audit = ["platform=darwin"]
+    skip_version_audit = ["platform=darwin", "platform=windows"]
 
     for ver, packages in _versions.items():
-        key = "{0}-{1}".format(platform.system(), platform.machine())
-        pkg = packages.get(key)
+        pkg = packages.get(f"{platform.system()}-{platform.machine()}")
         if pkg:
-            if ver == preferred_ver:
-                version(ver, sha256=pkg[0], url=pkg[1], expand=False, preferred=True)
-            else:
-                version(ver, sha256=pkg[0], url=pkg[1], expand=False)
+            version(ver, sha256=pkg[0], url=pkg[1], expand=False)
 
     # macOS Mojave drops NVIDIA graphics card support -- official NVIDIA
     # drivers do not exist for Mojave. See
@@ -627,6 +711,9 @@ class Cuda(Package):
     # https://www.nvidia.com/en-us/drivers/cuda/mac-driver-archive/ mention
     # Mojave support -- only macOS High Sierra 10.13 is supported.
     conflicts("arch=darwin-mojave-x86_64")
+
+    # cuda-12.8 libcusolver.so requires log2f@GLIBC_2.27
+    conflicts("glibc@:2.26", when="@12.8:")
 
     variant(
         "dev", default=False, description="Enable development dependencies, i.e to use cuda-gdb"
@@ -653,7 +740,7 @@ class Cuda(Package):
         match = re.search(r"Cuda compilation tools, release .*?, V(\S+)", output)
         return match.group(1) if match else None
 
-    def setup_build_environment(self, env):
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@:8.0.61"):
             # Perl 5.26 removed current directory from module search path,
             # CUDA 9 has a fix for this, but CUDA 8 and lower don't.
@@ -664,7 +751,9 @@ class Cuda(Package):
             env.set("LIBXML2HOME", libxml2_home)
             env.append_path("LD_LIBRARY_PATH", libxml2_home.lib)
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
         if "cxx" in dependent_spec:
             env.set("CUDAHOSTCXX", dependent_spec["cxx"].package.cxx)
         env.set("CUDA_HOME", self.prefix)
@@ -678,7 +767,7 @@ class Cuda(Package):
             cmake_prefix_paths.append(cub_path)
         return cmake_prefix_paths
 
-    def setup_run_environment(self, env):
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("CUDA_HOME", self.prefix)
         env.set("NVHPC_CUDA_HOME", self.prefix)
 
@@ -688,7 +777,7 @@ class Cuda(Package):
                 os.remove("/tmp/cuda-installer.log")
             except OSError:
                 if spec.satisfies("@10.1:"):
-                    tty.die(
+                    raise InstallError(
                         "The cuda installer will segfault due to the "
                         "presence of /tmp/cuda-installer.log "
                         "please remove the file and try again "
@@ -764,3 +853,6 @@ class Cuda(Package):
 
     # Avoid binding stub libraries by absolute path
     non_bindable_shared_objects = ["stubs"]
+
+    # contains precompiled binaries without rpaths
+    unresolved_libraries = ["*"]

--- a/site/repo/packages/cuda/package.py
+++ b/site/repo/packages/cuda/package.py
@@ -665,7 +665,8 @@ class Cuda(Package):
             env.append_path("LD_LIBRARY_PATH", libxml2_home.lib)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set("CUDAHOSTCXX", dependent_spec.package.compiler.cxx)
+        if "cxx" in dependent_spec:
+            env.set("CUDAHOSTCXX", dependent_spec["cxx"].package.cxx)
         env.set("CUDA_HOME", self.prefix)
         env.set("NVHPC_CUDA_HOME", self.prefix)
 

--- a/site/repo/packages/nvhpc/detection_test.yaml
+++ b/site/repo/packages/nvhpc/detection_test.yaml
@@ -1,0 +1,82 @@
+paths:
+- layout:
+  - executables:
+    - bin/nvc
+    script: |
+      echo "nvc 20.9-0 LLVM 64-bit target on x86-64 Linux -tp haswell"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  - executables:
+    - bin/nvc++
+    script: |
+      echo "nvc++ 20.9-0 LLVM 64-bit target on x86-64 Linux -tp haswell"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  - executables:
+    - bin/nvfortran
+    script: |
+      echo "nvfortran 20.9-0 LLVM 64-bit target on x86-64 Linux -tp haswell"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  platforms: [linux]
+  results:
+  - spec: nvhpc@20.9~blas~lapack~mpi
+    extra_attributes:
+      compilers:
+        c: ".*/bin/nvc"
+        cxx: ".*/bin/nvc\\+\\+"
+        fortran: ".*/bin/nvfortran"
+- layout:
+  - executables:
+    - bin/nvc
+    script: |
+      echo "nvc 20.9-0 linuxpower target on Linuxpower"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  - executables:
+    - bin/nvc++
+    script: |
+      echo "nvc++ 20.9-0 linuxpower target on Linuxpower"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  - executables:
+    - bin/nvfortran
+    script: |
+      echo "nvfortran 20.9-0 linuxpower target on Linuxpower"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  platforms: [linux]
+  results:
+  - spec: nvhpc@20.9~blas~lapack~mpi
+    extra_attributes:
+      compilers:
+        c: ".*/bin/nvc"
+        cxx: ".*/bin/nvc\\+\\+"
+        fortran: ".*/bin/nvfortran"
+- layout:
+  - executables:
+    - bin/nvc
+    script: |
+      echo "nvc 20.9-0 linuxarm64 target on aarch64 Linux"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  - executables:
+    - bin/nvc++
+    script: |
+      echo "nvc++ 20.9-0 linuxarm64 target on aarch64 Linux"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  - executables:
+    - bin/nvfortran
+    script: |
+      echo "nvfortran 20.9-0 linuxarm64 target on aarch64 Linux"
+      echo "NVIDIA Compilers and Tools"
+      echo "Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved."
+  platforms: [linux]
+  results:
+  - spec: nvhpc@20.9~blas~lapack~mpi
+    extra_attributes:
+      compilers:
+        c: ".*/bin/nvc"
+        cxx: ".*/bin/nvc\\+\\+"
+        fortran: ".*/bin/nvfortran"

--- a/site/repo/packages/nvhpc/package.py
+++ b/site/repo/packages/nvhpc/package.py
@@ -1,14 +1,16 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #
 # Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
-
+import glob
+import os.path
 import platform
 
+from spack_repo.builtin.build_systems.compiler import CompilerPackage
+from spack_repo.builtin.build_systems.generic import Package
+
 from spack.package import *
-from spack.util.prefix import Prefix
 
 # FIXME Remove hack for polymorphic versions
 # This package uses a ugly hack to be able to dispatch, given the same
@@ -23,82 +25,86 @@ from spack.util.prefix import Prefix
 _versions = {
     "25.3": {
         "Linux-aarch64": (
-            "15efadfa9c8597208c7b88d52affe6130b3eec3d4d6477778178c725f9b2d72e",
-            "https://developer.download.nvidia.com/hpc-sdk/25.3/nvhpc_2025_253_Linux_aarch64_cuda_12.8.tar.gz",
+            "a2b86cf5141c0a9b0925999521693981451a8d2403367c36c46238163be6f2bb",
+            "https://developer.download.nvidia.com/hpc-sdk/25.3/nvhpc_2025_253_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "57af8b63f6f2724c8e06e9d50727c63ce26eff89cd6f13d3eb3a779f1258fd85",
-            "https://developer.download.nvidia.com/hpc-sdk/25.3/nvhpc_2025_253_Linux_x86_64_cuda_12.8.tar.gz",
+            "e2b2c911478a5db6a15d1fd258a8c4004dbfccf6f32f4132fe142a24fb7e6f8f",
+            "https://developer.download.nvidia.com/hpc-sdk/25.3/nvhpc_2025_253_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "25.1": {
         "Linux-aarch64": (
-            "838b84f89371c83ded0c9eb660e5ff405f1759093b8fc8a67b6d23b8cafb5064",
-            "https://developer.download.nvidia.com/hpc-sdk/25.1/nvhpc_2025_251_Linux_aarch64_cuda_12.6.tar.gz",
+            "0e1d694d54d44559155024d5bab4ca6764eba52d3f27b89f5c252416976e0360",
+            "https://developer.download.nvidia.com/hpc-sdk/25.1/nvhpc_2025_251_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "c4b4d69c12983cbba394575acf2809ac610945f08496aba182cdbbee8b6bc9c4",
-            "https://developer.download.nvidia.com/hpc-sdk/25.1/nvhpc_2025_251_Linux_x86_64_cuda_12.6.tar.gz",
+            "0813791f8363f4c493db7891b00396ce522cb73910279b8f18a440aedda6727c",
+            "https://developer.download.nvidia.com/hpc-sdk/25.1/nvhpc_2025_251_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "24.11": {
         "Linux-aarch64": (
-            "9a353005fda4844c0ea30688f4a4feac882a25a40f8f7b686af0f793239e1f9e",
-            "https://developer.download.nvidia.com/hpc-sdk/24.11/nvhpc_2024_2411_Linux_aarch64_cuda_12.6.tar.gz",
+            "f2f64e5dec5e90dad5e12a31a992172b0aa19abf872ef1c54a1a437c7008eefb",
+            "https://developer.download.nvidia.com/hpc-sdk/24.11/nvhpc_2024_2411_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "39408ac062573936e0d41f34530ab065998ef4b85b6bcccb59287d71135a1920",
-            "https://developer.download.nvidia.com/hpc-sdk/24.11/nvhpc_2024_2411_Linux_x86_64_cuda_12.6.tar.gz",
+            "0c27d66ed0e2d3007d30ac904922a9abf96475197dc0f4dcc6316d235a1dc0c3",
+            "https://developer.download.nvidia.com/hpc-sdk/24.11/nvhpc_2024_2411_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "24.9": {
         "Linux-aarch64": (
-            "c9e63c37f3d1f874baa54581a757bcbe8cdcef4416d39695ae0f22aaaf2eb585",
-            "https://developer.download.nvidia.com/hpc-sdk/24.9/nvhpc_2024_249_Linux_aarch64_cuda_12.6.tar.gz",
+            "8d900f798ef806c64993fd4fedf2c2c812dd1ccdbac2a0d33fabcd0cd36f19cf",
+            "https://developer.download.nvidia.com/hpc-sdk/24.9/nvhpc_2024_249_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "5f8e9d03b6d3102884868cddf7ceacf60f3f21b63b13aee85a0466b3bbc8707c",
-            "https://developer.download.nvidia.com/hpc-sdk/24.9/nvhpc_2024_249_Linux_x86_64_cuda_12.6.tar.gz",
+            "30c493350cf67481e84cea60a3a869e01fa0bcb71df8e898266273fbdf0a7f26",
+            "https://developer.download.nvidia.com/hpc-sdk/24.9/nvhpc_2024_249_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "24.7": {
         "Linux-aarch64": (
-            "8b1659ad182e6b11203f1ab137f1b291da5863778e3786737e95f04fc26a4faf",
-            "https://developer.download.nvidia.com/hpc-sdk/24.7/nvhpc_2024_247_Linux_aarch64_cuda_12.5.tar.gz",
+            "256ae392ed961162f3f6dc633498db2b68441103a6192f5d4a1c18fa96e992e7",
+            "https://developer.download.nvidia.com/hpc-sdk/24.7/nvhpc_2024_247_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "baf20427c0057938a04bf2139429c6e9e1bb819de797636244c9696c2dcaf5b0",
-            "https://developer.download.nvidia.com/hpc-sdk/24.7/nvhpc_2024_247_Linux_x86_64_cuda_12.5.tar.gz",
+            "bf2094aa2fc5bdbcbf9bfa0fddc1cbed1bfa6e9342980649db2350d9f675f853",
+            "https://developer.download.nvidia.com/hpc-sdk/24.7/nvhpc_2024_247_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "24.5": {
         "Linux-aarch64": (
-            "d0a3bf265d4c08b97d94c83fb2b63b48e538d9f738a6dd0928029043bdeaaef6",
-            "https://developer.download.nvidia.com/hpc-sdk/24.5/nvhpc_2024_245_Linux_aarch64_cuda_12.4.tar.gz",
+            "c52b5ba370e053472cbffb825ba1da5b6abaee93d4e15479ec12c32d6ebc47d5",
+            "https://developer.download.nvidia.com/hpc-sdk/24.5/nvhpc_2024_245_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "392c3315dfe4c8bbd6d77ac9efff7a1af837447cca564cfbeff2d10682d365f5",
-            "https://developer.download.nvidia.com/hpc-sdk/24.5/nvhpc_2024_245_Linux_x86_64_cuda_12.4.tar.gz",
+            "e26c5027ffd83fd9e854946670a97253e950cdbacd4894a6715aea91070042ae",
+            "https://developer.download.nvidia.com/hpc-sdk/24.5/nvhpc_2024_245_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "24.3": {
         "Linux-aarch64": (
-            "6b9edc34b798ccaae39d4af36ff73465ee318ac49e5f96f5c5a2a0d7919fff15",
-            "https://developer.download.nvidia.com/hpc-sdk/24.3/nvhpc_2024_243_Linux_aarch64_cuda_12.3.tar.gz",
+            "6385847de5f8725e5c56d2abf70c90fed5490f2e71a7bd13d3f4ada8720ef036",
+            "https://developer.download.nvidia.com/hpc-sdk/24.3/nvhpc_2024_243_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "4fb8949ba8cef73b28818bd9375c9420ec48fab1c64e71315a7c1984f5329d6b",
-            "https://developer.download.nvidia.com/hpc-sdk/24.3/nvhpc_2024_243_Linux_x86_64_cuda_12.3.tar.gz",
+            "a9fe5ec878e9c4cc332de732c6739f97ac064ce76ad3d0af6d282658d27124cb",
+            "https://developer.download.nvidia.com/hpc-sdk/24.3/nvhpc_2024_243_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "24.1": {
         "Linux-aarch64": (
-            "8d2aafa8769115191708e41e63c647e1c975c241ce4bf6a0badf805f0f5edf1c",
-            "https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_aarch64_cuda_12.3.tar.gz",
+            "8c2ce561d5901a03eadce7f07dce5fbc55e8e88c87b74cf60e01e2eca231c41c",
+            "https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "e7330eb35e23dcd9b0b3bedc67c0d5443c4fd76b59caa894a76ecb0d17f71f43",
+            "https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_ppc64le_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "91cdc6f327881f14119e8b6e884d544aafab01c3d569b61831e259c91b4530fc",
-            "https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_x86_64_cuda_12.3.tar.gz",
+            "27992e5fd56af8738501830daddc5e9510ebd553326fea8730236fee4f0f1dd8",
+            "https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },
     "23.11": {
@@ -426,7 +432,7 @@ _versions = {
 }
 
 
-class Nvhpc(Package):
+class Nvhpc(Package, CompilerPackage):
     """The NVIDIA HPC SDK is a comprehensive suite of compilers, libraries
     and tools essential to maximizing developer productivity and the
     performance and portability of HPC applications. The NVIDIA HPC
@@ -442,15 +448,19 @@ class Nvhpc(Package):
     homepage = "https://developer.nvidia.com/hpc-sdk"
 
     maintainers("samcmill")
-    tags = ["e4s"]
+    tags = ["e4s", "compiler"]
 
-    skip_version_audit = ["platform=darwin"]
+    skip_version_audit = ["platform=darwin", "platform=windows"]
+
+    redistribute(source=False, binary=False)
 
     for ver, packages in _versions.items():
         key = "{0}-{1}".format(platform.system(), platform.machine())
         pkg = packages.get(key)
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
+
+    depends_on("gcc languages=c,c++,fortran", type="run")
 
     variant("blas", default=True, description="Enable BLAS")
     variant(
@@ -471,12 +481,49 @@ class Nvhpc(Package):
     provides("lapack", when="+lapack")
     provides("mpi", when="+mpi")
 
-    requires("%gcc", msg="nvhpc must be installed with %gcc")
+    provides("c", "cxx")
+    provides("fortran")
+
+    # For now we only detect compiler components
+    # It will require additional work to detect mpi/lapack/blas components
+    compiler_languages = ["c", "cxx", "fortran"]
+    c_names = ["nvc"]
+    cxx_names = ["nvc++"]
+    fortran_names = ["nvfortran"]
+    compiler_version_argument = "--version"
+    compiler_version_regex = r"nv[^ ]* (?:[^ ]+ Dev-r)?([0-9.]+)(?:-[0-9]+)?"
+
+    debug_flags = ["-g", "-gopt"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
+
+    pic_flag = "-fpic"
+    openmp_flag = "-mp"
+
+    compiler_wrapper_link_paths = {
+        "c": os.path.join("nvhpc", "nvc"),
+        "cxx": os.path.join("nvhpc", "nvc++"),
+        "fortran": os.path.join("nvhpc", "nvfortran"),
+    }
+
+    implicit_rpath_libs = ["libnvc", "libnvf"]
+    stdcxx_libs = ("-c++libs",)
+
+    def _standard_flag(self, *, language, standard):
+        flags = {
+            "cxx": {"11": "--c++11", "14": "--c++14", "17": "--c++17"},
+            "c": {"99": "-c99", "11": "-c11"},
+        }
+        return flags[language][standard]
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        # TODO: use other exes to determine default_cuda/install_type/blas/lapack/mpi variants
+        return "~blas~lapack~mpi", {"compilers": cls.determine_compiler_paths(exes=exes)}
 
     def _version_prefix(self):
         return join_path(self.prefix, "Linux_%s" % self.spec.target.family, self.version)
 
-    def setup_build_environment(self, env):
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
         env.set("NVHPC_SILENT", "true")
         env.set("NVHPC_ACCEPT_EULA", "accept")
         env.set("NVHPC_INSTALL_DIR", self.prefix)
@@ -497,11 +544,11 @@ class Nvhpc(Package):
 
         makelocalrc_args = [
             "-gcc",
-            self.compiler.cc,
+            self["gcc"].cc,
             "-gpp",
-            self.compiler.cxx,
+            self["gcc"].cxx,
             "-g77",
-            self.compiler.f77,
+            self["gcc"].fortran,
             "-x",
             compilers_bin,
         ]
@@ -515,7 +562,7 @@ class Nvhpc(Package):
         # Update localrc to use Spack gcc
         makelocalrc(*makelocalrc_args)
 
-    def setup_run_environment(self, env):
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
         prefix = Prefix(
             join_path(self.prefix, "Linux_%s" % self.spec.target.family, self.version, "compilers")
         )
@@ -543,7 +590,9 @@ class Nvhpc(Package):
             env.prepend_path("PATH", mpi_prefix.bin)
             env.prepend_path("LD_LIBRARY_PATH", mpi_prefix.lib)
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
         prefix = Prefix(
             join_path(self.prefix, "Linux_%s" % self.spec.target.family, self.version, "compilers")
         )
@@ -596,6 +645,24 @@ class Nvhpc(Package):
             libs.append("libnvf")
 
         return find_libraries(libs, root=prefix, recursive=True)
+
+    def _cc_path(self):
+        candidates = glob.glob(f"{self.prefix}/**/{self.spec.version}/compilers/bin/nvc")
+        if not candidates:
+            return None
+        return candidates[0]
+
+    def _cxx_path(self):
+        candidates = glob.glob(f"{self.prefix}/**/{self.spec.version}/compilers/bin/nvc++")
+        if not candidates:
+            return None
+        return candidates[0]
+
+    def _fortran_path(self):
+        candidates = glob.glob(f"{self.prefix}/**/{self.spec.version}/compilers/bin/nvfortran")
+        if not candidates:
+            return None
+        return candidates[0]
 
     # Avoid binding stub libraries by absolute path
     non_bindable_shared_objects = ["stubs"]

--- a/site/repo/packages/nvpl_blas/package.py
+++ b/site/repo/packages/nvpl_blas/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.generic import Package
+
 from spack.package import *
 
 

--- a/site/repo/packages/nvpl_lapack/package.py
+++ b/site/repo/packages/nvpl_lapack/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.generic import Package
+
 from spack.package import *
 
 

--- a/site/repo/packages/nvpl_scalapack/package.py
+++ b/site/repo/packages/nvpl_scalapack/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.generic import Package
+
 from spack.package import *
 
 
@@ -15,6 +17,8 @@ class NvplScalapack(Package):
     )
 
     maintainers("RMeli")
+
+    tags = ["e4s"]
 
     version("0.2.1", sha256="dada4d1ecf044d90609b9e62750b383d11be9b22c87e109414bcc07dce3c83c9")
 

--- a/todi/packages.yaml
+++ b/todi/packages.yaml
@@ -1,7 +1,4 @@
 packages:
-  aws-ofi-nccl:
-    version:
-    - 'git.v1.9.2-aws=1.9.2'
   # patchelf v0.18 leads to errors when it was used to set RPATHS
   #   ELF load command address/offset not properly aligned
   # c.f.  https://github.com/NixOS/patchelf/issues/492


### PR DESCRIPTION
This just collects all the changes needed for prgenv-gnu/25.06 and spack 1.0 (https://github.com/eth-cscs/alps-cluster-config/pulls?q=is%3Apr%20is%3Aopen%20label%3A%22spack%201.0%22) in one PR. It's not meant to be merged. It exists only to keep track that all the changes needed for prgenv-gnu/25.06 eventually get merged.