### PR TITLE
Set libfabric to buildable on all clusters

### DIFF
--- a/balfrin/packages.yaml
+++ b/balfrin/packages.yaml
@@ -13,7 +13,7 @@ packages:
   patchelf:
     require: "@:0.17"
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.15.2.0
       prefix: /opt/cray/libfabric/1.15.2.0/

--- a/beverin/packages.yaml
+++ b/beverin/packages.yaml
@@ -13,7 +13,7 @@ packages:
   patchelf:
     require: "@:0.17"
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.15.2.0
       prefix: /opt/cray/libfabric/1.15.2.0/

--- a/bristen/packages.yaml
+++ b/bristen/packages.yaml
@@ -7,7 +7,7 @@ packages:
   cray-mpich:
     buildable: true
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.15.2.0
       prefix: /opt/cray/libfabric/1.15.2.0/

--- a/clariden/packages.yaml
+++ b/clariden/packages.yaml
@@ -13,7 +13,7 @@ packages:
   patchelf:
     require: "@:0.17"
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.22.0
       prefix: /opt/cray/libfabric/1.22.0/

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -18,7 +18,7 @@ packages:
     - spec: xpmem@2.9.6
       prefix: /usr
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.22.0
       prefix: /opt/cray/libfabric/1.22.0/

--- a/eiger/packages.yaml
+++ b/eiger/packages.yaml
@@ -13,7 +13,7 @@ packages:
   patchelf:
     require: "@:0.17"
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.15.2.0
       prefix: /opt/cray/libfabric/1.15.2.0/

--- a/pilatus/packages.yaml
+++ b/pilatus/packages.yaml
@@ -13,7 +13,7 @@ packages:
   patchelf:
     require: "@:0.17"
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.15.2.0
       prefix: /opt/cray/libfabric/1.15.2.0/

--- a/santis/packages.yaml
+++ b/santis/packages.yaml
@@ -13,7 +13,7 @@ packages:
   patchelf:
     require: "@:0.17"
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.22.0
       prefix: /opt/cray/libfabric/1.22.0/

--- a/tasna/packages.yaml
+++ b/tasna/packages.yaml
@@ -14,7 +14,7 @@ packages:
   patchelf:
     require: "@:0.17"
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.15.2.0
       prefix: /opt/cray/libfabric/1.15.2.0/

--- a/todi/packages.yaml
+++ b/todi/packages.yaml
@@ -13,7 +13,7 @@ packages:
   patchelf:
     require: "@:0.17"
   libfabric:
-    buildable: false
+    buildable: true
     externals:
     - spec: libfabric@1.15.2.0
       prefix: /opt/cray/libfabric/1.15.2.0/


### PR DESCRIPTION
Part of the changes in #23, but useful already on its own to test custom libfabric builds without all the infrastructure in #23 and https://github.com/eth-cscs/stackinator/pull/210.