### PR TITLE
Fixes for cray-mpich+cuda on daint

### DIFF
--- a/site/spack_repo/alps/packages/cray_gtl/package.py
+++ b/site/spack_repo/alps/packages/cray_gtl/package.py
@@ -83,14 +83,14 @@ class CrayGtl(Package):
     conflicts("+cuda", when="+rocm", msg="Pick either CUDA or ROCM")
 
     with when("+cuda"):
-        depends_on("cuda@11.0:11", type="link", when="@:8.1.26")
-        depends_on("cuda@12.0:12", type="link", when="@8.1.27:")
+        depends_on("cuda@11.0:11", when="@:8.1.26")
+        depends_on("cuda@12.0:12", when="@8.1.27:")
 
     with when("+rocm"):
         # libamdhip64.so.5
-        depends_on("hip@5:", type="link")
+        depends_on("hip@5:")
         # libhsa-runtime64.so.1
-        depends_on("hsa-rocr-dev", type="link")
+        depends_on("hsa-rocr-dev")
 
     def get_rpaths(self):
         # Those rpaths are already set in the build environment, so

--- a/site/spack_repo/alps/packages/cray_gtl/package.py
+++ b/site/spack_repo/alps/packages/cray_gtl/package.py
@@ -133,7 +133,7 @@ class CrayGtl(Package):
                 # The C compiler wrapper can fail because libmpi_gtl_cuda refers to the symbol
                 # __gxx_personality_v0 but wasn't linked against libstdc++.
                 if "libmpi_gtl_cuda.so" in str(f):
-                    patchelf("--add-needed", "libstdc++.so", f, fail_on_error=False)
+                    patchelf("--add-needed", "libstdc++.so.6", f, fail_on_error=False)
                 if "@8.1.27+cuda" in self.spec:
                     patchelf("--add-needed", "libcudart.so", f, fail_on_error=False)
                     patchelf("--add-needed", "libcuda.so", f, fail_on_error=False)

--- a/site/spack_repo/alps/packages/cray_mpich/package.py
+++ b/site/spack_repo/alps/packages/cray_mpich/package.py
@@ -117,9 +117,9 @@ class CrayMpich(Package):
         "9.0.0",
     ]:
         with when("+cuda"):
-            depends_on(f"cray-gtl@{ver} +cuda", type="link", when="@" + ver)
+            depends_on(f"cray-gtl@{ver} +cuda", when="@" + ver)
         with when("+rocm"):
-            depends_on(f"cray-gtl@{ver} +rocm", type="link", when="@" + ver)
+            depends_on(f"cray-gtl@{ver} +rocm", when="@" + ver)
 
     depends_on("libfabric@1:", type="link")
 


### PR DESCRIPTION
The detection of `mpi` can fail when `cray-mpich` is installed with `cuda` enabled. 