### PR TITLE
remove patchelf with libdstdc++ for cray-gtl

### DIFF
--- a/site/repo/packages/cray-gtl/package.py
+++ b/site/repo/packages/cray-gtl/package.py
@@ -128,10 +128,6 @@ class CrayGtl(Package):
                 if not self.should_patch(f):
                     continue
                 patchelf("--force-rpath", "--set-rpath", rpath, f, fail_on_error=False)
-                # The C compiler wrapper can fail because libmpi_gtl_cuda refers to the symbol
-                # __gxx_personality_v0 but wasn't linked against libstdc++.
-                if "libmpi_gtl_cuda.so" in str(f):
-                    patchelf("--add-needed", "libstdc++.so", f, fail_on_error=False)
                 if "@8.1.27+cuda" in self.spec:
                     patchelf("--add-needed", "libcudart.so", f, fail_on_error=False)
                     patchelf("--add-needed", "libcuda.so", f, fail_on_error=False)


### PR DESCRIPTION
versions from 8.1.18 (oldest available) are already linked to libstdc++ or don't contain the _gxx_personality_v0 symbol

same as #53 but for `releases/v5`