### PR TITLE
cray-mpich: fix, it was not using spack compiler wrappers

### DIFF
--- a/site/spack_repo/alps/packages/cray_mpich/package.py
+++ b/site/spack_repo/alps/packages/cray_mpich/package.py
@@ -7,6 +7,7 @@ import os
 import platform
 
 from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 import spack.compilers
 from spack.package import *
@@ -55,7 +56,7 @@ _versions = {
 }
 
 
-class CrayMpich(Package):
+class CrayMpich(MpichEnvironmentModifications, Package):
     """Install cray-mpich as a binary package"""
 
     """Intended to override the main cray-mpich"""
@@ -128,27 +129,6 @@ class CrayMpich(Package):
 
     conflicts("%gcc@:7")
     conflicts("%gcc@:11", when="@8.1.28:")
-
-    def setup_run_environment(self, env):
-        env.set("MPICC", join_path(self.prefix.bin, "mpicc"))
-        env.set("MPICXX", join_path(self.prefix.bin, "mpic++"))
-        env.set("MPIF77", join_path(self.prefix.bin, "mpif77"))
-        env.set("MPIF90", join_path(self.prefix.bin, "mpif90"))
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-        if "c" in dependent_spec:
-            env.set("MPICH_CC", dependent_spec["c"].package.cc)
-        if"cxx" in dependent_spec:
-            env.set("MPICH_CXX", dependent_spec["cxx"].package.cxx)
-        if "fortran" in dependent_spec:
-            env.set("MPICH_FC", dependent_spec["fortran"].package.fortran)
-
-    def setup_dependent_package(self, module, dependent_spec):
-        self.spec.mpicc = join_path(self.prefix.bin, "mpicc")
-        self.spec.mpicxx = join_path(self.prefix.bin, "mpic++")
-        self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
-        self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
 
     def get_rpaths(self):
         # Those rpaths are already set in the build environment, so


### PR DESCRIPTION
In the migration to spack 1.0 with #30 we inadvertently switch from using spack compiler wrappers (with all their support for correctly setting build flags) to using the "plain" regular compiler.

This ended up with build problems (see https://github.com/spack/spack-packages/pull/1193) because not using the spack compiler wrapper means not using `SPACK_STORE_*` variables that contains information about include/libs of all dependencies. This was more damaging for some build systems than others, but it might be that this triggered also subtle problems (possibly #51?).