### PR TITLE
Require `libfabric fabrics=lnx` for openmpi builds

### DIFF
--- a/site/network/a100/network.yaml
+++ b/site/network/a100/network.yaml
@@ -2,7 +2,7 @@ mpi:
   cray-mpich:
     specs: ["libfabric@1.22"]
   openmpi:
-    specs: ["libfabric@2.2.0"]
+    specs: ["libfabric@2.2.0 fabrics=lnx"]
 packages:
   # adding a variant to the variants field of a package
   #   e.g. packages:openmpi:variants

--- a/site/network/amdgpu/network.yaml
+++ b/site/network/amdgpu/network.yaml
@@ -2,7 +2,7 @@ mpi:
   cray-mpich:
     specs: ["libfabric@1.22"]
   openmpi:
-    specs: ["libfabric@2.2.0"]
+    specs: ["libfabric@2.2.0 fabrics=lnx"]
 packages:
   # adding a variant to the variants field of a package
   #   e.g. packages:openmpi:variants

--- a/site/network/gh200/network.yaml
+++ b/site/network/gh200/network.yaml
@@ -2,7 +2,7 @@ mpi:
   cray-mpich:
     specs: ["libfabric@1.22"]
   openmpi:
-    specs: ["libfabric@2.2.0"]
+    specs: ["libfabric@2.2.0 fabrics=lnx"]
 packages:
   # adding a variant to the variants field of a package
   #   e.g. packages:openmpi:variants

--- a/site/network/zen/network.yaml
+++ b/site/network/zen/network.yaml
@@ -2,7 +2,7 @@ mpi:
   cray-mpich:
     specs: ["libfabric@1.22"]
   openmpi:
-    specs: ["libfabric@2.2.0"]
+    specs: ["libfabric@2.2.0 fabrics=lnx"]
 packages:
   # adding a variant to the variants field of a package
   #   e.g. packages:openmpi:variants


### PR DESCRIPTION
The `lnx` fabric specified in specs gets merged with the required fabrics `cxi,rxm,tcp` specified further down in the `network.yaml` file.