### PR TITLE
Update package API version to 2.2 for use of `memoized`

### DIFF
--- a/site/spack_repo/alps/repo.yaml
+++ b/site/spack_repo/alps/repo.yaml
@@ -1,3 +1,3 @@
 repo:
   namespace: alps
-  api: v2.0
+  api: v2.2


### PR DESCRIPTION
Declare the correct package API version. The openmpi package uses `memoized` which is part of the package API v2.2 (https://spack.readthedocs.io/en/latest/package_api.html#spack.package.memoized). This _should_ help spack give a better error message if spack doesn't support the given package API.