### PR TITLE
Add cuda 12.9 and nvhpc 25.7 to releases/v5

### DIFF
--- a/site/repo/packages/cuda/package.py
+++ b/site/repo/packages/cuda/package.py
@@ -25,6 +25,16 @@ from spack.package import *
 
 preferred_ver = "12.6.0"
 _versions = {
+    "12.9.0": {
+        "Linux-aarch64": (
+            "f3b7ae71f95d11de0a03ccfa1c0aff7be336d2199b50b1a15b03695fd15a6409",
+            "https://developer.download.nvidia.com/compute/cuda/12.9.0/local_installers/cuda_12.9.0_575.51.03_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "bbce2b760fe2096ca1c86f729e03bf377c1519add7b2755ecc4e9b0a9e07ee43",
+            "https://developer.download.nvidia.com/compute/cuda/12.9.0/local_installers/cuda_12.9.0_575.51.03_linux.run",
+        ),
+    },
     "12.8.0": {
         "Linux-aarch64": (
             "5bc211f00c4f544da6e3fc3a549b3eb0a7e038439f5f3de71caa688f2f6b132c",

--- a/site/repo/packages/nvhpc/package.py
+++ b/site/repo/packages/nvhpc/package.py
@@ -21,6 +21,16 @@ from spack.util.prefix import Prefix
 #  - package key must be in the form '{os}-{arch}' where 'os' is in the
 #    format returned by platform.system() and 'arch' by platform.machine()
 _versions = {
+    "25.7": {
+        "Linux-aarch64": (
+            "ca882aab5f40f6d43311436b36dc32f57d0190654a0022ea4299b82e30918f09",
+            "https://developer.download.nvidia.com/hpc-sdk/25.7/nvhpc_2025_257_Linux_aarch64_cuda_12.9.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "4c688ef2b0f71017de6e2ac1fb8accfb970a1c2c129b1c01bba499fe98b03923",
+            "https://developer.download.nvidia.com/hpc-sdk/25.7/nvhpc_2025_257_Linux_x86_64_cuda_12.9.tar.gz",
+        ),
+    },
     "25.5": {
         "Linux-aarch64": (
             "5378c53a38c2cd5efa3ee92c578c0656a8d341778619b9dfd4487dd636c5418b",


### PR DESCRIPTION
Required for updating the VASP uenv.