### PR TITLE
Use SHS packages (libcxi, cxi-driver, cassini-headers) installed on clusters

### DIFF
--- a/balfrin/network.yaml
+++ b/balfrin/network.yaml
@@ -29,9 +29,21 @@ packages:
       prefix: /opt/cray/libfabric/1.15.2.0/
     version: ["1.15.2.0"]
     require: fabrics=cxi,rxm,tcp,rxd,udp
+  # the SHS version on balfrin is 11.1.0
+  # however, this is not supported by the open source releases so we say 12.0 for now
   libcxi:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: libcxi@12.0.2 +cuda
+      prefix: /usr
   cxi-driver:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cxi-driver@12.0.2
+      prefix: /usr
   cassini-headers:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cassini-headers@12.0.2
+      prefix: /usr
+

--- a/site/network/a100/network.yaml
+++ b/site/network/a100/network.yaml
@@ -29,10 +29,21 @@ packages:
       prefix: /opt/cray/libfabric/1.22.0/
     version: ["2.2.0"]
     require: fabrics=cxi,rxm,tcp
+  # todo: 12.0 is the closest to the shs 11.1.0 installed on the system
   libcxi:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: libcxi@12.0.2 +cuda
+      prefix: /usr
   cxi-driver:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cxi-driver@12.0.2
+      prefix: /usr
   cassini-headers:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cassini-headers@12.0.2
+      prefix: /usr
+
 

--- a/site/network/a100/network.yaml
+++ b/site/network/a100/network.yaml
@@ -29,21 +29,20 @@ packages:
       prefix: /opt/cray/libfabric/1.22.0/
     version: ["2.2.0"]
     require: fabrics=cxi,rxm,tcp
-  # todo: 12.0 is the closest to the shs 11.1.0 installed on the system
   libcxi:
     buildable: false
     externals:
-    - spec: libcxi@12.0.2 +cuda
+    - spec: libcxi@11.1.0 +cuda
       prefix: /usr
   cxi-driver:
     buildable: false
     externals:
-    - spec: cxi-driver@12.0.2
+    - spec: cxi-driver@11.1.0
       prefix: /usr
   cassini-headers:
     buildable: false
     externals:
-    - spec: cassini-headers@12.0.2
+    - spec: cassini-headers@11.1.0
       prefix: /usr
 
 

--- a/site/network/gh200/network.yaml
+++ b/site/network/gh200/network.yaml
@@ -36,9 +36,18 @@ packages:
       - '+gdrcopy'
     require: fabrics=cxi,rxm,tcp
   libcxi:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: libcxi@12.0.2 +cuda
+      prefix: /usr
   cxi-driver:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cxi-driver@12.0.2
+      prefix: /usr
   cassini-headers:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cassini-headers@12.0.2
+      prefix: /usr
 

--- a/site/network/zen/network.yaml
+++ b/site/network/zen/network.yaml
@@ -31,10 +31,21 @@ packages:
     prefer:
       - '@2.2:'
     require: fabrics=cxi,rxm,tcp
+  # todo: 12.0 is the closest to the shs 11.1.0 installed on the system
   libcxi:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: libcxi@12.0.0
+      prefix: /usr
   cxi-driver:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cxi-driver@12.0.0
+      prefix: /usr
   cassini-headers:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cassini-headers@12.0.0
+      prefix: /usr
+
 

--- a/site/network/zen/network.yaml
+++ b/site/network/zen/network.yaml
@@ -31,21 +31,20 @@ packages:
     prefer:
       - '@2.2:'
     require: fabrics=cxi,rxm,tcp
-  # todo: 12.0 is the closest to the shs 11.1.0 installed on the system
   libcxi:
     buildable: false
     externals:
-    - spec: libcxi@12.0.0
+    - spec: libcxi@11.1.0
       prefix: /usr
   cxi-driver:
     buildable: false
     externals:
-    - spec: cxi-driver@12.0.0
+    - spec: cxi-driver@11.1.0
       prefix: /usr
   cassini-headers:
     buildable: false
     externals:
-    - spec: cassini-headers@12.0.0
+    - spec: cassini-headers@11.1.0
       prefix: /usr
 
 

--- a/starlex/network.yaml
+++ b/starlex/network.yaml
@@ -26,18 +26,26 @@ packages:
   libfabric:
     buildable: true
     externals:
-      # the 1.22.0 directory contains version 1.25.0
-      - spec: libfabric@1.25.0 fabrics=cxi,rxm,tcp,rxd,udp,shm +cuda cuda_arch=90,90a
-        prefix: /opt/cray/libfabric/1.22.0
+      - spec: libfabric@2.3.1 fabrics=cxi,rxm,tcp,rxd,udp,shm +cuda cuda_arch=90,90a
+        prefix: /opt/cray/libfabric/2.3.1
     prefer:
       - '@2.2:'
       - '+cuda'
       - '+gdrcopy'
     require: fabrics=cxi,rxm,tcp
   libcxi:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: libcxi@13.1.0 +cuda
+      prefix: /usr
   cxi-driver:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cxi-driver@13.1.0
+      prefix: /usr
   cassini-headers:
-    version: ["git.release/shs-13.0.0=13.0.0"]
+    buildable: false
+    externals:
+    - spec: cassini-headers@13.1.0
+      prefix: /usr
 


### PR DESCRIPTION
We learnt from HPE that the libcxi dependency of libfabric needs to match the cxi driver version installed on the system.

We have been building the latest available version of these dependencies, which could create subtle problems.

I used the `versions` tool in the repo to update these dependencies to the versions that best match the system versions

* note that some systems have SHS 11.1.0 installed, for which there is not perfect match. We just pretend that the installed versions are 12.0.0, which is probably okay (and certainly better than downloading 13.0)